### PR TITLE
Add ability to pass custom/additional command line arguments to executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For example,
   in [packer](https://github.com/wbthomason/packer.nvim) simply:
 
 ```lua
-  use { 'timtro/glslView-nvim', ft = 'glsl', config = require('glslView').setup }
+  use { 'timtro/glslView-nvim', ft = 'glsl' }
 ```
 Don't forget to `PackerCompile` after installation so that the plugin will only
   be loaded for glsl files.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,15 @@ When editing GLSL shaders,
   this plugin provides the command `GlslView` which will open 
   [glslViewer](https://github.com/patriciogonzalezvivo/glslViewer)
   to the file being edited in the current buffer.
-It is opened with the `-l` flag so that `glslViewer` will automatically listen
+By default, it is opened with the `-l` flag so that `glslViewer` will automatically listen
   for file changes,
   updating the preview as you save.
+It takes 0 or more arguments to pass to the `glslViewer` executable,
+  for example:
+
+```vimscript
+:GlslView -w 128 -h 256
+```
 
 ## 📦 Installation
 Install the plugin with your preferred package manager.
@@ -28,21 +34,18 @@ See [installation](https://github.com/patriciogonzalezvivo/glslViewer/wiki/Insta
 
 
 ## ⚙️ Configuration
-The only configuration currently available is setting the executable file path for glslViewer
-
-This can be done by passing the `exe_path` option to `setup()`.
-For example,
-  in [packer](https://github.com/wbthomason/packer.nvim) simply:
+Configuration is done by passing options to `setup()`:
 
 ```lua
-  use {
-    'timtro/glslView-nvim',
-    ft = 'glsl',
-    config = function()
-      require('glslView').setup { exe_path = "/path/to/glslView.exe" }
-    end
-  }
+require('glslView').setup {
+  exe_path = '/path/to/glslViewer',
+  arguments = { '-l', '-w', '128', '-h', '256' },
+}
 ```
+
+The default options are:
+ * `exe_path`: `'glslViewer'`
+ * `arguments`: `{ '-l' }`
 
 ## 💪 Usage
 Simply use the command `:GlslView` to open the current buffer in glslViewer.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For example,
   in [packer](https://github.com/wbthomason/packer.nvim) simply:
 
 ```lua
-  use { 'timtro/glslView-nvim', ft = 'glsl' }
+  use { 'timtro/glslView-nvim', ft = 'glsl', config = require('glslView').setup }
 ```
 Don't forget to `PackerCompile` after installation so that the plugin will only
   be loaded for glsl files.
@@ -28,10 +28,21 @@ See [installation](https://github.com/patriciogonzalezvivo/glslViewer/wiki/Insta
 
 
 ## ⚙️ Configuration
-  * Not yet implemented.
-  * The only configuration features planned will allow setting the executable 
-      file path for glslViewer—so no big rush until someone tells me they need
-      this.
+The only configuration currently available is setting the executable file path for glslViewer
+
+This can be done by passing the `exe_path` option to `setup()`.
+For example,
+  in [packer](https://github.com/wbthomason/packer.nvim) simply:
+
+```lua
+  use {
+    'timtro/glslView-nvim',
+    ft = 'glsl',
+    config = function()
+      require('glslView').setup { exe_path = "/path/to/glslView.exe" }
+    end
+  }
+```
 
 ## 💪 Usage
 Simply use the command `:GlslView` to open the current buffer in glslViewer.

--- a/README.md
+++ b/README.md
@@ -7,12 +7,6 @@ When editing GLSL shaders,
 By default, it is opened with the `-l` flag so that `glslViewer` will automatically listen
   for file changes,
   updating the preview as you save.
-It takes 0 or more arguments to pass to the `glslViewer` executable,
-  for example:
-
-```vimscript
-:GlslView -w 128 -h 256
-```
 
 ## 📦 Installation
 Install the plugin with your preferred package manager.
@@ -49,6 +43,14 @@ The default options are:
 
 ## 💪 Usage
 Simply use the command `:GlslView` to open the current buffer in glslViewer.
+
+Additional arguments will be passed to the executable after any arguments set in configuration.
+
+For example, to start with a 128x256 window:
+
+```vimscript
+:GlslView -w 128 -h 256
+```
 
 ## 🧰 Alternatives
  * [vim-GlslViewer](https://github.com/patriciogonzalezvivo/vim-glslViewer) -

--- a/lua/glslView.lua
+++ b/lua/glslView.lua
@@ -1,5 +1,10 @@
 local M = {}
 
+M.config = {
+  exe_path = 'glslView',
+  arguments = { '-l' },
+}
+
 M.glslView = function()
   local bufnr = vim.api.nvim_get_current_buf()
   local full_file_path = vim.api.nvim_buf_get_name(0)
@@ -7,7 +12,6 @@ M.glslView = function()
   local handle -- pre-declared to avoid diagnostic error.
   handle = vim.loop.spawn(
     M.config.exe_path,
-    { args = { full_file_path, '-l' } },
     function()
       handle:close()
     end
@@ -27,10 +31,6 @@ M.glslView = function()
 end
 
 M.setup = function(opts)
-  M.config = {
-    exe_path = 'glslView',
-  }
-
   if opts ~= nil then
     M.config = vim.tbl_deep_extend('force', M.config, opts)
   end

--- a/lua/glslView.lua
+++ b/lua/glslView.lua
@@ -2,16 +2,21 @@ local M = {}
 
 M.config = {
   exe_path = 'glslView',
-  arguments = { '-l' },
+  args = { '-l' },
 }
 
-M.glslView = function()
+M.glslView = function(command_args)
   local bufnr = vim.api.nvim_get_current_buf()
   local full_file_path = vim.api.nvim_buf_get_name(0)
+
+  local exe_args = { full_file_path }
+  table.move(M.config.args, 1, #M.config.args, #exe_args+1, exe_args);
+  table.move(command_args, 1, #command_args, #exe_args+1, exe_args);
 
   local handle -- pre-declared to avoid diagnostic error.
   handle = vim.loop.spawn(
     M.config.exe_path,
+    { args = exe_args },
     function()
       handle:close()
     end

--- a/lua/glslView.lua
+++ b/lua/glslView.lua
@@ -6,7 +6,7 @@ M.glslView = function()
 
   local handle -- pre-declared to avoid diagnostic error.
   handle = vim.loop.spawn(
-    'glslViewer',
+    M.config.exe_path,
     { args = { full_file_path, '-l' } },
     function()
       handle:close()
@@ -23,6 +23,16 @@ M.glslView = function()
         end
       end,
     })
+  end
+end
+
+M.setup = function(opts)
+  M.config = {
+    exe_path = 'glslView',
+  }
+
+  if opts ~= nil then
+    M.config = vim.tbl_deep_extend('force', M.config, opts)
   end
 end
 

--- a/plugin/glslView.vim
+++ b/plugin/glslView.vim
@@ -1,3 +1,3 @@
 
-command! -nargs=0 -bar GlslView :lua require'glslView'.glslView()
+command! -nargs=* -bar GlslView :lua require'glslView'.glslView({ <f-args> })
 " autocmd! BufNewFile,BufRead  *.frag GlslView


### PR DESCRIPTION
Adds both the ability to change the default options passed via `require('glslView').setup{}`, and also modifies the `GlslView` command to take 0 or more *additional* options to pass to the executable. 

For example. to always start @ 30fps, 128x128:

```lua
require('glslView').setup {
  arguments = { '-l', '--fps', 30 , '-w', 128, '-h', 128 }
}
```

Any arguments passed to `GlslView` are appended *after* the values in the configuration so as to override them.