### PR TITLE
Fix event loop spawn hook so that it is backwards compatible

### DIFF
--- a/lua/glslView.lua
+++ b/lua/glslView.lua
@@ -14,7 +14,8 @@ M.glslView = function(command_args)
   vim.list_extend(viewer_args, command_args)
 
   local handle -- pre-declared to avoid diagnostic error.
-  handle = vim.uv.spawn(M.config.viewer_path, { args = viewer_args }, function()
+  local nvim_event_loop = vim.uv or vim.loop
+  handle = nvim_event_loop.spawn(M.config.viewer_path, { args = viewer_args }, function()
     handle:close()
   end)
 


### PR DESCRIPTION
# Motivation
Latest stable neovim version (currently 0.9.5) does not include `vim.uv` (yet) so this does not work. Implement a fix that prefers the newer API but will fall back to the previous API.

# Related
- https://github.com/timtro/glslView-nvim/commit/b60b8278d464725d8308631eeeb3e0118f09a72e
- https://github.com/neovim/neovim/pull/22846